### PR TITLE
Fix cache and numerous other things 

### DIFF
--- a/lib/nconf-etcd.js
+++ b/lib/nconf-etcd.js
@@ -23,6 +23,8 @@ var NconfEtcd = exports.Etcd = function(host, port, options) {
   if (typeof options !== 'object') options = {};
 
   this.type      = 'etcd';
+  this.logger    = options.logger;
+  this.level     = options.loggerLevel || 'debug';
   this.namespace = options.namespace;
   this.host      = host || options.host || 'localhost';
   this.port      = port || options.port || '4001';
@@ -81,9 +83,11 @@ NconfEtcd.prototype.get = function(key, callback) {
   // the value set for this instance, return from the cache.
   //
   if (mtime && now - mtime < this.ttl) {
+    if (this.logger) this.logger[this.level]('[nconf-etcd] GET: %s from cache', fullkey);
     return callback(null, this.cache.get(fullkey));
   }
 
+  if (this.logger) this.logger[this.level]('[nconf-etcd] GET: %s', fullkey);
   this.etcd.get(key, {recursive: true}, function(err, resp) {
     if (err) {
       // Rather than throwin errors, an unknown key will returned undefined
@@ -91,6 +95,7 @@ NconfEtcd.prototype.get = function(key, callback) {
         if (self.cache) self.cache.set(fullkey, null);
         return callback();
       }
+      if (self.logger) self.logger.warn(err, '[nconf-etcd] GET ERROR: %s', fullkey);
       return callback(err);
     }
 
@@ -113,6 +118,7 @@ NconfEtcd.prototype.set = function(key, value, callback) {
   // TODO - This will not work for setting nested objects. I might need to add that
   // In the nconf-redis module it stores each js key as a path separator. This does not
   if (this.cache) this.cache.set(fullkey, value);
+  if (this.logger) this.logger[this.level]('[nconf-etcd] SET: %s', fullkey);
 
   if (typeof value === 'object') {
     value = JSON.stringify(value);
@@ -133,6 +139,7 @@ NconfEtcd.prototype.clear = function(key, callback) {
 
   key = this.etcdKey(fullkey);
 
+  if (this.logger) this.logger[this.level]('[nconf-etcd] CLEAR: %s', fullkey);
   this.etcd.del(key, {recursive: true}, function(err, res) {
     if (!err && self.cache) self.cache.clear();
     callback(err, res);
@@ -167,8 +174,11 @@ NconfEtcd.prototype.reset = function(callback) {
   //we don't want to accidentally delete and/or remove
   //everything if namespace was accidentally forgotten.
   if (!this.namespace) {
+    if (this.logger) this.logger.warn('[nconf-etcd] CLEAR ERROR: Will not clear etcd when namespace is empty');
     return callback(new Error('Clearing etcd without a namespace can have destructive effect.'));
   }
+
+  if (this.logger) this.logger[this.level]('[nconf-etcd] RESET');
 
   var self = this;
   this.etcd.del(this.namespace + '/', {recursive: true}, function(err){

--- a/lib/nconf-etcd.js
+++ b/lib/nconf-etcd.js
@@ -23,14 +23,18 @@ var NconfEtcd = exports.Etcd = function(host, port, options) {
   if (typeof options !== 'object') options = {};
 
   this.type      = 'etcd';
-  this.namespace = (options.namespace) || 'nconf';
+  this.namespace = options.namespace;
   this.host      = host || options.host || 'localhost';
   this.port      = port || options.port || '4001';
   this.sslopts   = options.sslopts;
   this.cache     = (options.cache !== false) && new nconf.Memory();
   this.ttl       = options.ttl  || 60 * 60 * 1000;
-
   this.etcd      = new Etcd(this.host, this.port, this.sslopts);
+
+  //Make namespace optional but with backwards compatibility behavior.
+  if (!this.namespace && this.namespace !== null) {
+    this.namespace = 'nconf'
+  }
   return this;
 };
 
@@ -41,8 +45,21 @@ var NconfEtcd = exports.Etcd = function(host, port, options) {
 nconf.Etcd = NconfEtcd;
 
 NconfEtcd.prototype.etcdKey = function(key) {
-  return key.replace(/:/g, '/');
+  //Add support for empty key. This gives us all values.
+  return key && key.replace(/:/g, '/') || '/';
 };
+
+/**
+ * Formats a key to full path making sure to considerate both
+ * the namespace or the key being null.
+ *
+ * @param key
+ */
+NconfEtcd.prototype.fullKey = function(key) {
+  if (this.namespace && key) return nconf.key(this.namespace, key);
+  if (this.namespace) return this.namespace;
+  return key;
+}
 
 /**
  * Gets a key from the
@@ -50,12 +67,12 @@ NconfEtcd.prototype.etcdKey = function(key) {
  * @param callback
  */
 NconfEtcd.prototype.get = function(key, callback) {
-
   var now     = Date.now(),
-      fullkey = nconf.key(this.namespace, key),
+      self    = this,
+      fullkey = this.fullKey(key),
       mtime   = this.cache && this.cache.mtimes[fullkey];
 
-  key = this.etcdKey(key);
+  key = this.etcdKey(fullkey);
 
   // Set the callback if not provided for "fire and forget"
   callback = callback || function (err, value) { return value; };
@@ -71,6 +88,7 @@ NconfEtcd.prototype.get = function(key, callback) {
     if (err) {
       // Rather than throwin errors, an unknown key will returned undefined
       if (err.errorCode === 100) {
+        if (self.cache) self.cache.set(fullkey, null);
         return callback();
       }
       return callback(err);
@@ -81,36 +99,49 @@ NconfEtcd.prototype.get = function(key, callback) {
       val = JSON.parse(val);
     } catch (e) {}
 
+    if (self.cache) self.cache.set(fullkey, val);
+
     return callback(null, val);
   });
 };
 
 NconfEtcd.prototype.set = function(key, value, callback) {
-  key = nconf.key(this.namespace, key);
-  if (this.cache) this.cache.set(key, value);
-  key = this.etcdKey(key);
+  var fullkey = this.fullKey(key)
+
+  key = this.etcdKey(fullkey);
 
   // TODO - This will not work for setting nested objects. I might need to add that
   // In the nconf-redis module it stores each js key as a path separator. This does not
+  if (this.cache) this.cache.set(fullkey, value);
 
-  var val = value;
-  if (typeof val === 'object') {
-    val = JSON.stringify(val);
+  if (typeof value === 'object') {
+    value = JSON.stringify(value);
   }
-  this.etcd.set(key, val, callback);
+  this.etcd.set(key, value, callback);
 };
 
 NconfEtcd.prototype.clear = function(key, callback) {
-  key = nconf.key(this.namespace, key);
-  key = this.etcdKey(key);
+  var self = this,
+      fullkey = this.fullKey(key);
+
+  //If etcd happens to share instance with other services
+  //we don't want to accidentally delete and/or remove
+  //everything if namespace and key was accidentally forgotten.
+  if (!fullkey) {
+    return callback(new Error('Clearing etcd without a namespace and key can have destructive effect.'));
+  }
+
+  key = this.etcdKey(fullkey);
 
   this.etcd.del(key, {recursive: true}, function(err, res) {
+    if (!err && self.cache) self.cache.clear();
     callback(err, res);
   });
 };
 
 NconfEtcd.prototype.merge = function(key, value, callback) {
   var self = this;
+  
   function setAndDone(value) {
     return self.set(key, value, callback);
   }
@@ -132,13 +163,23 @@ NconfEtcd.prototype.merge = function(key, value, callback) {
 };
 
 NconfEtcd.prototype.reset = function(callback) {
-  this.etcd.del(this.namespace + '/', {recursive: true}, function(err){
+  //If etcd happens to share instance with other services
+  //we don't want to accidentally delete and/or remove
+  //everything if namespace was accidentally forgotten.
+  if (!this.namespace) {
+    return callback(new Error('Clearing etcd without a namespace can have destructive effect.'));
+  }
 
+  var self = this;
+  this.etcd.del(this.namespace + '/', {recursive: true}, function(err){
+    if (self.cache) self.cache.reset();
     // when no keys are found, just ignore the error
     if (!err || err.errorCode === 100) return callback();
     return callback(err);
   });
 };
+
+
 
 //// ### function reset (callback)
 //// #### @callback {function} Continuation to respond to when complete.

--- a/package.json
+++ b/package.json
@@ -26,13 +26,14 @@
   },
   "homepage": "https://github.com/irony/nconf-etcd",
   "devDependencies": {
+    "chai": "~1.9.1",
     "mocha": "~1.20.1",
-    "nconf": "~0.6.9",
-    "chai": "~1.9.1"
+    "nconf": "~0.6.9"
   },
   "dependencies": {
+    "lodash": "^2.4.1",
     "node-etcd": "^2.1.1",
-    "lodash": "^2.4.1"
+    "sinon": "^1.12.2"
   },
   "readme": "An etcd store for nconf"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nconf-etcd",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "An etcd store for nconf",
   "main": "lib/nconf-etcd.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nconf-etcd",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "An etcd store for nconf",
   "main": "lib/nconf-etcd.js",
   "directories": {

--- a/test/nconf-etcd.spec.js
+++ b/test/nconf-etcd.spec.js
@@ -250,8 +250,9 @@ describe('subsets', function () {
     nconf.set('test:mongo:host', 'mongo');
     var host = nconf.get('test:mongo:host');
     host.should.equal('mongo');
-    var port = nconf.get('test:mongo:port');
-    port.should.equal('333');
+    var port = nconf.get('test:mongo:port', function(err, port) {
+      port.should.equal('333');
+    });
   })
 });
 

--- a/test/nconf-etcd.spec.js
+++ b/test/nconf-etcd.spec.js
@@ -1,5 +1,6 @@
 var
   should      = require('chai').should(),
+  sinon       = require('sinon'),
   nconf       = require('nconf'),
   data        = require('nconf/test/fixtures/data').data,
   merge       = require('nconf/test/fixtures/data').merge;
@@ -233,6 +234,27 @@ describe('cache', function () {
     });
   });
 
+});
+
+describe('logging', function () {
+  before(function () {
+    this.logger = {
+      debug: sinon.stub()
+    };
+    nconf.use('etcd', {host: SERVER, port: PORT, logger: this.logger});
+  });
+
+  it('should log into the debugger if specified', function (done) {
+    var stub = this.logger.debug;
+    nconf.set('foo', 'barz');
+    stub.calledOnce.should.equal(true);
+    nconf.get('foo', function(err, value){
+      should.not.exist(err);
+      stub.calledOnce.should.equal(false);
+      stub.calledTwice.should.equal(true);
+      done()
+    })
+  });
 });
 
 describe('subsets', function () {


### PR DESCRIPTION
- Add cache for get()
- Added logging support
- Added support for null namespace
- Added support for null key in get
- Consistency for what key and fullkey are
- Both reset() and clear() now clear out cache
- Lock reset() or clear() when both key & namespace are empty
